### PR TITLE
Add a /paths handler to see active bgp announcements from gocast

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ COPY . /go/src/github.com/mayuresh82/gocast
 
 WORKDIR /go/src/github.com/mayuresh82/gocast
 
-RUN make
+RUN make linux
 
-FROM alpine:latest
+FROM --platform=amd64 alpine:latest
 RUN apk --no-cache add ca-certificates bash iptables netcat-openbsd sudo
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/mayuresh82/gocast .

--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,4 @@ test:
 	go test -v -race -short -failfast -mod=vendor ./...
 
 linux:
-	GOOS=linux GOARCH=amd64 go build -o gocast_linux -mod=vendor .
+	GOOS=linux GOARCH=amd64 go build -o gocast -mod=vendor .

--- a/controller/bgp.go
+++ b/controller/bgp.go
@@ -162,6 +162,19 @@ func (c *Controller) PeerInfo() (*api.Peer, error) {
 	return peer, nil
 }
 
+func (c *Controller) PathInfo() (destinations []api.Destination, err error) {
+	req := api.ListPathRequest{
+		TableType: api.TableType_GLOBAL,
+		Name: "",
+		Family: &api.Family{Afi: api.Family_AFI_IP, Safi: api.Family_SAFI_UNICAST},
+		SortType: api.ListPathRequest_PREFIX,
+	}
+	err = c.s.ListPath(context.Background(), &req, func(dst *api.Destination) {
+		destinations = append(destinations, *dst)
+	})
+	return
+}
+
 func (c *Controller) Shutdown() error {
 	if err := c.s.ShutdownPeer(context.Background(), &api.ShutdownPeerRequest{
 		Address: c.peerIP.String(),

--- a/controller/monitor.go
+++ b/controller/monitor.go
@@ -384,3 +384,8 @@ func (m *MonitorMgr) Cleanup(app string, exit chan bool) {
 func (m *MonitorMgr) GetInfo() (*api.Peer, error) {
 	return m.ctrl.PeerInfo()
 }
+
+// GetPathInfo returns info about our BGP announcement state
+func (m *MonitorMgr) GetPathInfo() ([]api.Destination, error) {
+       return m.ctrl.PathInfo()
+}

--- a/server/server.go
+++ b/server/server.go
@@ -32,6 +32,7 @@ func (s *Server) Serve(ctx context.Context) {
 	http.HandleFunc("/unregister", s.unregisterHandler)
 	http.HandleFunc("/info", s.infoHandler)
 	http.HandleFunc("/ping", s.pingHandler)
+	http.HandleFunc("/paths", s.pathsHandler)
 	srv := &http.Server{Addr: s.ListenAddr}
 	idleConnsClosed := make(chan struct{})
 	go func() {
@@ -104,4 +105,14 @@ func (s *Server) pingHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+}
+
+func (s *Server) pathsHandler(w http.ResponseWriter, r *http.Request) {
+	destinations, err := s.mon.GetPathInfo()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Internal error getting path info: %v", err), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(destinations)
 }


### PR DESCRIPTION
This is a very basic first iteration that tells us the prefixes that are announced. Unfortunately the "gobgp global rib" command has a bunch of logic to decode the extra details like community attributes and next hop address that it directly prints to stdout rather than returning as string, so we will unfortunately need to reimplement some of that logic to get those extra details. Shouldn't be too hard since there is working code to derive from so I will give it a shot.

Example output from hkg1 test site:

```
ubuntu@tn33-ak07-hkg1:~$ curl -s localhost:8080/paths | jq .
[
  {
    "prefix": "128.116.30.193/32",
    "paths": [
      {
        "nlri": {
          "type_url": "type.googleapis.com/gobgpapi.IPAddressPrefix",
          "value": "CCASDjEyOC4xMTYuMzAuMTkz"
        },
        "pattrs": [
          {
            "type_url": "type.googleapis.com/gobgpapi.OriginAttribute"
          },
          {
            "type_url": "type.googleapis.com/gobgpapi.CommunitiesAttribute",
            "value": "Cg+lnKXFBZfOpMUFg/qlxQU="
          },
          {
            "type_url": "type.googleapis.com/gobgpapi.NextHopAttribute",
            "value": "CgwxMC4xNjYuMS4yMjg="
          }
        ],
        "age": {
          "seconds": 1691702144
        },
        "best": true,
        "validation": {},
        "family": {
          "afi": 1,
          "safi": 1
        },
        "source_id": "<nil>",
        "neighbor_ip": "<nil>",
        "local_identifier": 1
      }
    ]
  }
]

```

And the same thing used to check all the announcements at a POP:

```
12:25:09 ~/git/traffic-squid/nomad_files/gocast $for h in $( tt site-hosts -r te_nomad_client hkg1 ); do echo $h; nssh $h 'curl -s localhost:8080/paths|jq .[0].prefix|cut -d'\''"'\'' -f2|cut -d/ -f1'; echo; done
tn4-ak03-hkg1
128.116.30.194

tn09d-ad01-hkg1
null

tn17b-ad03-hkg1
128.116.30.195

tn33-ak07-hkg1
128.116.30.193
```